### PR TITLE
AIP-6921: Refactor List RoleBindings method to broaden checks on user/role to Kubernetes native subjects and roleRefs.

### DIFF
--- a/components/access-management/kfam/bindings.go
+++ b/components/access-management/kfam/bindings.go
@@ -186,7 +186,7 @@ func (c *BindingClient) List(user string, namespaces []string, role string) (*Bi
 		for _, roleBinding := range roleBindings {
 			var subject rbacv1.Subject
 			for _, roleBindingSubject := range roleBinding.Subjects {
-				if roleBindingSubject.Kind == USER && roleBindingSubject.Name == user {
+				if roleBindingSubject.Kind == rbacv1.UserKind && roleBindingSubject.Name == user {
 					subject = roleBindingSubject
 					break
 				}
@@ -202,12 +202,18 @@ func (c *BindingClient) List(user string, namespaces []string, role string) (*Bi
 				subject = roleBinding.Subjects[0]
 			}
 			
-			roleVal, ok := roleBinding.Annotations[ROLE]
-			if !ok {
-				continue
-			}
-			if role != "" && role != roleVal && role != roleBinding.RoleRef.Name {
-				continue
+			if role != "" {
+				if role != roleBinding.RoleRef.Name {
+					continue
+				}
+
+				roleVal, ok := roleBinding.Annotations[ROLE]
+				if !ok {
+					continue
+				}
+				if role != roleVal {
+					continue
+				}
 			}
 			binding := Binding{
 				User: &rbacv1.Subject{

--- a/components/access-management/kfam/bindings.go
+++ b/components/access-management/kfam/bindings.go
@@ -184,7 +184,7 @@ func (c *BindingClient) List(user string, namespaces []string, role string) (*Bi
 			return nil, err
 		}
 		for _, roleBinding := range roleBindings {
-			subject = nil
+			var subject rbacv1.Subject = nil
 			for _, roleBindingSubject := range roleBinding.Subjects {
 				if roleBindingSubject.Kind == USER && roleBindingSubject.Name == user {
 					subject = roleBindingSubject

--- a/components/access-management/kfam/bindings.go
+++ b/components/access-management/kfam/bindings.go
@@ -191,7 +191,7 @@ func (c *BindingClient) List(user string, namespaces []string, role string) (*Bi
 					break
 				}
 			}
-			if subject == rbacv1.Subject{} {
+			if subject == (rbacv1.Subject{}) {
 				userVal, ok := roleBinding.Annotations[USER]
 				if !ok {
 					continue

--- a/components/access-management/kfam/bindings.go
+++ b/components/access-management/kfam/bindings.go
@@ -184,14 +184,14 @@ func (c *BindingClient) List(user string, namespaces []string, role string) (*Bi
 			return nil, err
 		}
 		for _, roleBinding := range roleBindings {
-			var subject rbacv1.Subject = nil
+			var subject rbacv1.Subject
 			for _, roleBindingSubject := range roleBinding.Subjects {
 				if roleBindingSubject.Kind == USER && roleBindingSubject.Name == user {
 					subject = roleBindingSubject
 					break
 				}
 			}
-			if roleBindingSubject == nil {
+			if subject == rbacv1.Subject{} {
 				userVal, ok := roleBinding.Annotations[USER]
 				if !ok {
 					continue


### PR DESCRIPTION
To enable us to simplify our `User` to `ClusterRole` (for the default `kubeflow-*` roles), refactor the checks in the `List` method to broaden applicability. Currently they rely on weird behavior around a hard-coded set of `annotations`, this PR changes that to check the `RoleBinding` `Subjects` and `RoleRef` instead.

This will enable us to go from a single `RoleBinding` per `User`, per `Namespace` to a single `RoleBinding` per `Namespace`. This new simplified, singular `RoleBinding` could bind multiple `Subjects` (ie. `Users`) so we go from `O(N*U)` (where `N` = # of namespace, `U` is # of users in that namespace), to just `O(N)` `RoleBinding` resources! Simplifying our deployment and debugging practices 😎 