### PR TITLE
AIP-6921: Add in Gitlab CI pipeline to default branch to build out KFAM image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,38 @@
+variables:
+  MAJOR_VERSION: "0"
+  MINOR_VERSION: "1"
+  ORGANIZATION_NAME: "artificial-intelligence"
+  TEAM_NAME: "ai-platform"
+
+.build_templatized_docker_image:
+  before_script:
+    # Turn on debug logging to output commands with vars to make local testing easier.
+    - set -x
+    # Inject org & team names to conform to AIP naming conventions that make it possible to set
+    # permissions and retention policies at each level.
+    - IMAGE_REPOSITORY_PREFIX="${DOCKER_REPO_URL}/${ORGANIZATION_NAME}/${TEAM_NAME}"
+    # Ensure image tag is unique for each commit so we invalidate caching on machines pulling images.
+    - IMAGE_TAG="${MAJOR_VERSION}.${MINOR_VERSION}.${CI_PIPELINE_IID}"
+    # Actually set up the naming for the image we're currently building.
+    - IMAGE_REPOSITORY="${IMAGE_REPOSITORY_PREFIX}/${ARTIFACT_NAME}"
+    - IMAGE_REPOSITORY_TAG="${IMAGE_REPOSITORY}:${IMAGE_TAG}"
+  script:
+    - |
+      DOCKER_BUILDKIT=1 docker build \
+        --build-arg BUILDKIT_INLINE_CACHE=1 \
+        --build-arg "IMAGE_REPOSITORY_TAG=${IMAGE_REPOSITORY_TAG}" \
+        -t ${IMAGE_REPOSITORY_TAG} \
+        -f ${DOCKERFILE}/Dockerfile \
+        components
+    - echo ${DOCKER_API_KEY} | docker login -u ${DOCKER_USERNAME} --password-stdin ${DOCKER_REPO_URL}
+    - docker push ${IMAGE_REPOSITORY_TAG}
+
+stages:
+  - build:images
+
+build:access-management-image:
+  extends: .build_templatized_docker_image
+  variables:
+    ARTIFACT_NAME: "access-management"
+    DOCKERFILE: "components/access-management"
+  stage: build:images

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,8 +22,7 @@ variables:
         --build-arg BUILDKIT_INLINE_CACHE=1 \
         --build-arg "IMAGE_REPOSITORY_TAG=${IMAGE_REPOSITORY_TAG}" \
         -t ${IMAGE_REPOSITORY_TAG} \
-        -f ${DOCKERFILE}/Dockerfile \
-        components
+        ${CONTEXT}
     - echo ${DOCKER_API_KEY} | docker login -u ${DOCKER_USERNAME} --password-stdin ${DOCKER_REPO_URL}
     - docker push ${IMAGE_REPOSITORY_TAG}
 
@@ -34,5 +33,5 @@ build:access-management-image:
   extends: .build_templatized_docker_image
   variables:
     ARTIFACT_NAME: "access-management"
-    DOCKERFILE: "components/access-management"
+    CONTEXT: "components/access-management"
   stage: build:images

--- a/components/access-management/kfam/bindings.go
+++ b/components/access-management/kfam/bindings.go
@@ -186,7 +186,7 @@ func (c *BindingClient) List(user string, namespaces []string, role string) (*Bi
 		for _, roleBinding := range roleBindings {
 			var subject rbacv1.Subject
 			for _, roleBindingSubject := range roleBinding.Subjects {
-				if roleBindingSubject.Kind == USER && roleBindingSubject.Name == user {
+				if roleBindingSubject.Kind == rbacv1.UserKind && roleBindingSubject.Name == user {
 					subject = roleBindingSubject
 					break
 				}
@@ -202,12 +202,18 @@ func (c *BindingClient) List(user string, namespaces []string, role string) (*Bi
 				subject = roleBinding.Subjects[0]
 			}
 			
-			roleVal, ok := roleBinding.Annotations[ROLE]
-			if !ok {
-				continue
-			}
-			if role != "" && role != roleVal && role != roleBinding.RoleRef.Name {
-				continue
+			if role != "" {
+				if role != roleBinding.RoleRef.Name {
+					continue
+				}
+
+				roleVal, ok := roleBinding.Annotations[ROLE]
+				if !ok {
+					continue
+				}
+				if role != roleVal {
+					continue
+				}
 			}
 			binding := Binding{
 				User: &rbacv1.Subject{

--- a/components/access-management/kfam/bindings.go
+++ b/components/access-management/kfam/bindings.go
@@ -184,7 +184,7 @@ func (c *BindingClient) List(user string, namespaces []string, role string) (*Bi
 			return nil, err
 		}
 		for _, roleBinding := range roleBindings {
-			subject = nil
+			var subject rbacv1.Subject = nil
 			for _, roleBindingSubject := range roleBinding.Subjects {
 				if roleBindingSubject.Kind == USER && roleBindingSubject.Name == user {
 					subject = roleBindingSubject

--- a/components/access-management/kfam/bindings.go
+++ b/components/access-management/kfam/bindings.go
@@ -191,7 +191,7 @@ func (c *BindingClient) List(user string, namespaces []string, role string) (*Bi
 					break
 				}
 			}
-			if subject == rbacv1.Subject{} {
+			if subject == (rbacv1.Subject{}) {
 				userVal, ok := roleBinding.Annotations[USER]
 				if !ok {
 					continue

--- a/components/access-management/kfam/bindings.go
+++ b/components/access-management/kfam/bindings.go
@@ -184,14 +184,14 @@ func (c *BindingClient) List(user string, namespaces []string, role string) (*Bi
 			return nil, err
 		}
 		for _, roleBinding := range roleBindings {
-			var subject rbacv1.Subject = nil
+			var subject rbacv1.Subject
 			for _, roleBindingSubject := range roleBinding.Subjects {
 				if roleBindingSubject.Kind == USER && roleBindingSubject.Name == user {
 					subject = roleBindingSubject
 					break
 				}
 			}
-			if roleBindingSubject == nil {
+			if subject == rbacv1.Subject{} {
 				userVal, ok := roleBinding.Annotations[USER]
 				if !ok {
 					continue


### PR DESCRIPTION
Supercedes the [original PR](https://github.com/zillow/kubeflow/pull/1).

To enable us to simplify our `User` to `ClusterRole` (for the default `kubeflow-*` roles), refactor the checks in the `List` method to broaden applicability. Currently they rely on weird behavior around a hard-coded set of `annotations`, this PR changes that to check the `RoleBinding` `Subjects` and `RoleRef` instead.

This will enable us to go from a single `RoleBinding` per `User`, per `Namespace` to a single `RoleBinding` per `Namespace`. This new simplified, singular `RoleBinding` could bind multiple `Subjects` (ie. `Users`) so we go from `O(N*U)` (where `N` = # of namespace, `U` is # of users in that namespace), to just `O(N)` `RoleBinding` resources! Simplifying our deployment and debugging practices 😎 

--

Additionally adds in `.gitlab-ci.yml` file for building the KFAM image fork for ZG use.