### PR TITLE
AIP-7049: Swap out legacy label with refactored AI Platform one

### DIFF
--- a/components/access-management/kfam/api_default.go
+++ b/components/access-management/kfam/api_default.go
@@ -227,10 +227,9 @@ func (c *KfamV1Alpha1Client) ReadBinding(w http.ResponseWriter, r *http.Request)
 	namespaces := []string{}
 	// by default scan all namespaces created by the platform
 	if queries.Get("namespace") == "" {
-		// TODO AIP-7049 Replace app.kubernetes.io/part-of=kubeflow-profile selector
 		// Forked from the original open source to remove the Profile concept as it adds little
 		// benefit to us.
-		namespaceSelector, _ := labels.Parse("app.kubernetes.io/part-of=kubeflow-profile")
+		namespaceSelector, _ := labels.Parse("zodiac.zillowgroup.net/platform=ai-platform")
 		namespaceList, err := c.namespaceLister.List(namespaceSelector)
 		if err != nil {
 			w.WriteHeader(http.StatusForbidden)

--- a/components/access-management/kfam/api_default.go
+++ b/components/access-management/kfam/api_default.go
@@ -229,7 +229,7 @@ func (c *KfamV1Alpha1Client) ReadBinding(w http.ResponseWriter, r *http.Request)
 	if queries.Get("namespace") == "" {
 		// Forked from the original open source to remove the Profile concept as it adds little
 		// benefit to us.
-		namespaceSelector, _ := labels.Parse("zodiac.zillowgroup.net/platform=ai-platform")
+		namespaceSelector, _ := labels.Parse("zodiac.zillowgroup.net/platform=aip")
 		namespaceList, err := c.namespaceLister.List(namespaceSelector)
 		if err != nil {
 			w.WriteHeader(http.StatusForbidden)


### PR DESCRIPTION
For wider context on this change see [this PR](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/aip-infrastructure/kubeflow-k8s-profiles/-/merge_requests/773) description.